### PR TITLE
add license title; use recommended license text

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,6 @@
+ISC License
+
 Copyright (c) 2016, Marcin Bachry
-All rights reserved.
 
 Permission to use, copy, modify, and/or distribute this software for any
 purpose with or without fee is hereby granted, provided that the above


### PR DESCRIPTION
The title is not strictly required, but it's useful metadata, and part of the recommended license template text (see http://choosealicense.com/licenses/isc/ and https://opensource.org/licenses/isc-license).
